### PR TITLE
Added stop() and start() methods and updated examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,26 +17,26 @@ Usage
 
 Create a white noise generator and route it to the output:
 
-~~~~ {.javascript}
-var context = new webkitAudioContext();
+```javascript
+var context = new AudioContext();
 var whiteNoise = context.createWhiteNoise();
 whiteNoise.connect(context.destination);
-~~~~
+```
 
 ### Pink Noise
 
 Create a pink noise generator and route it to the output:
 
-~~~~ {.javascript}
-var context = new webkitAudioContext();
+```javascript
+var context = new AudioContext();
 var pinkNoise = context.createPinkNoise();
 pinkNoise.connect(context.destination);
-~~~~
+```
 
 Modulate a sawtooth oscillator with filtered pink noise:
 
 ```javascript
-var context = new webkitAudioContext();
+var context = new AudioContext();
 var pinkNoise = context.createPinkNoise();
 var pinkGain = context.createGainNode();
 var pinkFilter = context.createBiquadFilter();
@@ -61,16 +61,16 @@ sawGain.connect(context.destination);
 
 Create a brown noise generator and route it to the output:
 
-~~~~ {.javascript}
-var context = new webkitAudioContext();
+```javascript
+var context = new AudioContext();
 var brownNoise = context.createBrownNoise();
 brownNoise.connect(context.destination);
-~~~~
+```
 
 Modulate the brown noise amplitude to simulate the sound of the ocean:
 
 ```javascript
-var context = new webkitAudioContext();
+var context = new AudioContext();
 var brownNoise = context.createBrownNoise();
 var brownGain = context.createGainNode();
 brownGain.gain.value = 0.3;

--- a/noise.js
+++ b/noise.js
@@ -2,11 +2,21 @@
 	AudioContext.prototype.createWhiteNoise = function(bufferSize) {
 		bufferSize = bufferSize || 4096;
 		var node = this.createScriptProcessor(bufferSize, 1, 1);
+		var playing = true;
 		node.onaudioprocess = function(e) {
 			var output = e.outputBuffer.getChannelData(0);
 			for (var i = 0; i < bufferSize; i++) {
 				output[i] = Math.random() * 2 - 1;
+				if (!playing) {
+					output[i] = null;
+				}
 			}
+		}
+		node.stop = function() {
+			playing = false;
+		}
+		node.start = function() {
+			playing = true;
 		}
 		return node;
 	};
@@ -16,6 +26,7 @@
 		var b0, b1, b2, b3, b4, b5, b6;
 		b0 = b1 = b2 = b3 = b4 = b5 = b6 = 0.0;
 		var node = this.createScriptProcessor(bufferSize, 1, 1);
+		var playing = true;
 		node.onaudioprocess = function(e) {
 			var output = e.outputBuffer.getChannelData(0);
 			for (var i = 0; i < bufferSize; i++) {
@@ -29,7 +40,16 @@
 				output[i] = b0 + b1 + b2 + b3 + b4 + b5 + b6 + white * 0.5362;
 				output[i] *= 0.11; // (roughly) compensate for gain
 				b6 = white * 0.115926;
+				if (!playing) {
+					output[i] = null;
+				}
 			}
+		}
+		node.stop = function() {
+			playing = false;
+		}
+		node.start = function() {
+			playing = true;
 		}
 		return node;
 	};
@@ -38,6 +58,7 @@
 		bufferSize = bufferSize || 4096;
 		var lastOut = 0.0;
 		var node = this.createScriptProcessor(bufferSize, 1, 1);
+		var playing = true;
 		node.onaudioprocess = function(e) {
 			var output = e.outputBuffer.getChannelData(0);
 			for (var i = 0; i < bufferSize; i++) {
@@ -45,7 +66,16 @@
 				output[i] = (lastOut + (0.02 * white)) / 1.02;
 				lastOut = output[i];
 				output[i] *= 3.5; // (roughly) compensate for gain
+				if (!playing) {
+					output[i] = null;
+				}
 			}
+		}
+		node.stop = function() {
+			playing = false;
+		}
+		node.start = function() {
+			playing = true;
 		}
 		return node;
 	};

--- a/noise.js
+++ b/noise.js
@@ -2,21 +2,21 @@
 	AudioContext.prototype.createWhiteNoise = function(bufferSize) {
 		bufferSize = bufferSize || 4096;
 		var node = this.createScriptProcessor(bufferSize, 1, 1);
-		var playing = true;
+		var muted = false;
 		node.onaudioprocess = function(e) {
 			var output = e.outputBuffer.getChannelData(0);
 			for (var i = 0; i < bufferSize; i++) {
 				output[i] = Math.random() * 2 - 1;
-				if (!playing) {
+				if (muted) {
 					output[i] = null;
 				}
 			}
 		}
-		node.stop = function() {
-			playing = false;
+		node.mute = function() {
+			muted = true;
 		}
-		node.start = function() {
-			playing = true;
+		node.unmute = function() {
+			muted = false;
 		}
 		return node;
 	};
@@ -26,7 +26,7 @@
 		var b0, b1, b2, b3, b4, b5, b6;
 		b0 = b1 = b2 = b3 = b4 = b5 = b6 = 0.0;
 		var node = this.createScriptProcessor(bufferSize, 1, 1);
-		var playing = true;
+		var muted = false;
 		node.onaudioprocess = function(e) {
 			var output = e.outputBuffer.getChannelData(0);
 			for (var i = 0; i < bufferSize; i++) {
@@ -40,16 +40,16 @@
 				output[i] = b0 + b1 + b2 + b3 + b4 + b5 + b6 + white * 0.5362;
 				output[i] *= 0.11; // (roughly) compensate for gain
 				b6 = white * 0.115926;
-				if (!playing) {
+				if (muted) {
 					output[i] = null;
 				}
 			}
 		}
-		node.stop = function() {
-			playing = false;
+		node.mute = function() {
+			muted = true;
 		}
-		node.start = function() {
-			playing = true;
+		node.unmute = function() {
+			muted = false;
 		}
 		return node;
 	};
@@ -58,7 +58,7 @@
 		bufferSize = bufferSize || 4096;
 		var lastOut = 0.0;
 		var node = this.createScriptProcessor(bufferSize, 1, 1);
-		var playing = true;
+		var muted = false;
 		node.onaudioprocess = function(e) {
 			var output = e.outputBuffer.getChannelData(0);
 			for (var i = 0; i < bufferSize; i++) {
@@ -66,16 +66,16 @@
 				output[i] = (lastOut + (0.02 * white)) / 1.02;
 				lastOut = output[i];
 				output[i] *= 3.5; // (roughly) compensate for gain
-				if (!playing) {
+				if (muted) {
 					output[i] = null;
 				}
 			}
 		}
-		node.stop = function() {
-			playing = false;
+		node.mute = function() {
+			muted = true;
 		}
-		node.start = function() {
-			playing = true;
+		node.unmute = function() {
+			muted = false;
 		}
 		return node;
 	};


### PR DESCRIPTION
I appreciate I didn't raise an issue for this first but it was such a quick change I thought I'd go ahead an make a pull-request. Please if you think it bloats out the code too much feel free to reject the request, I'll understand. 

I have added a `mute()` and `unmute()` method to the instances of ScriptProcessorNode that are returned. 

I have also updated the examples in the README.md to use `AudioContext` as _most_ browsers support it now (whereas at the time you wrote this most browsers didn't).  

Cheers